### PR TITLE
Fix indentation in gen_request so count works

### DIFF
--- a/sipping.py
+++ b/sipping.py
@@ -225,15 +225,15 @@ def gen_request(template_vars, options):
                 except Exception, e:
                     sys.stderr.write("ERROR: cannot open file %s. %s\n" % (options.request_template, e))
                     sys.exit(-1)
-        try:
-            req = Request(request)
-        except SipUnpackError, e:
-            sys.stderr.write("ERROR: malformed SIP Request. %s\n" % e)
-            sys.exit(-1)
+            try:
+                req = Request(request)
+            except SipUnpackError, e:
+                sys.stderr.write("ERROR: malformed SIP Request. %s\n" % e)
+                sys.exit(-1)
 
-        if "cseq" not in req.headers:
-            req.headers["cseq"] = "%d %s" % (i, req.method)
-        yield str(req)
+            if "cseq" not in req.headers:
+                req.headers["cseq"] = "%d %s" % (i, req.method)
+            yield str(req)
 
 
 def open_sock(options):


### PR DESCRIPTION
Specifying count was ignored and everything ran once due to wrong indentation. Sometimes if you didn't specify count, everything would just hang. This fixes that as well.